### PR TITLE
Fix tag access

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -9,9 +9,8 @@ describe("Parser", function() {
 		<div class="title">Ll</div>
 		<div class="content">Hearts of darkness<br>Water ship down<br>The Dubliners<br><br></div>
 		<div class="labels"><span class="label">Reading List</span><span class="label">Another Tag</span></div>
-		</div></body></html>
+    </div></body></html>
 		`;
-
     var note = parse(data);
     expect(note.title).toBe("Ll");
     expect(note.content).toBe(
@@ -21,7 +20,28 @@ describe("Parser", function() {
     expect(note.archived).toBe(false);
     expect(note.date).toBe("2016-06-21T22:39:47.000Z");
   });
+  test("Should parse alternate tag structure", function() {
+    var data = `
+		<html><body><div class="note DEFAULT"><div class="heading">
+		21 Jun 2016, 22:39:47</div>
+		<div class="title">Ll</div>
+		<div class="content">Hearts of darkness<br>Water ship down<br>The Dubliners<br><br></div>
+    <div class="chips">
+    <span class="chip label"><span class="label-name">Chip Label 1</span></span>
+    <span class="chip label"><span class="label-name">Chip Label 2</span>
+    </div>
+		</body></html>
+    `;
 
+    var note = parse(data);
+    expect(note.title).toBe("Ll");
+    expect(note.content).toBe(
+      "Hearts of darkness\nWater ship down\nThe Dubliners"
+    );
+    expect(note.tags).toEqual(["Chip Label 1", "Chip Label 2"]);
+    expect(note.archived).toBe(false);
+    expect(note.date).toBe("2016-06-21T22:39:47.000Z");
+  });
   test("Should parse lists", function() {
     var data = fs.readFileSync(__dirname + "/test_data/lists.html").toString();
     var note = parse(data);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -66,7 +66,15 @@ export function parse(data: string) {
       if (!elem.children) {
         return null;
       }
-      return elem.children[0].children[0].data;
+      // classic tags format: <div class="labels"><span class="label">
+      if (elem.children[0].data) {
+        return elem.children[0].data
+      }
+      // alternate tags format: <div class="chips"><span class="chip label"><span class="label-name">
+      if (elem.children[0].children && elem.children[0].children[0].data) {
+        return elem.children[0].children[0].data;
+      }
+      return null;
     });
 
   var attachments = $("div.attachments").toArray();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -66,7 +66,7 @@ export function parse(data: string) {
       if (!elem.children) {
         return null;
       }
-      return elem.children[0].data;
+      return elem.children[0].children[0].data;
     });
 
   var attachments = $("div.attachments").toArray();


### PR DESCRIPTION
Hi,
Thank you for this super-useful tool. I only found it did not fetch any tags (they all were `null`). Seems the takeout format has changed. I had to add a second `children[0]` to the tag access code to be able to fetch the tags. 

Please review and merge if you agree to the changes.