### PR TITLE
fix: use `Buffer.from` instead of deprecated `new Buffer`

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -74,6 +74,6 @@ function generateAttachment(a: string) {
   var matches = a.substr(0, 100).match(regex);
   var ext = matches[1];
   var data = a.substr(a.indexOf("base64") + 7);
-  var buffer = new Buffer(data, "base64");
+  var buffer = Buffer.from(data, "base64");
   return [uuidV4() + "." + ext, buffer];
 }


### PR DESCRIPTION
Resolves an error during attachment import

```
(node:563578) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

Should fix #10 